### PR TITLE
teres1-ledcrtl: input device by path

### DIFF
--- a/SOFTWARE/A64-TERES/teres1-ledctrl/teres1-ledctrl.c
+++ b/SOFTWARE/A64-TERES/teres1-ledctrl/teres1-ledctrl.c
@@ -53,7 +53,9 @@ void usage(void)
 {
   extern char *program_invocation_short_name;
   printf("USAGE:\n");
-  printf("   %s /dev/input/eventX\n", program_invocation_short_name);
+  printf("   %s INPUT_DEVICE\n", program_invocation_short_name);
+  printf("for example,\n");
+  printf("   %s '/dev/input/by-path/platform-1c1b000.ehci1-controller-usb-0:1.4:1.0-event-kbd'\n", program_invocation_short_name);
   printf("\n");
 }
 


### PR DESCRIPTION
I wanted to add this to the previous PR, but is has been merged already. This is cosmetic.

Usage should advise something less obscure and more permanent than `/dev/input/eventX`, because it can easily change if for example an external keyboard is attached. 

Using by-path, as in [debian/teres1-ledctrl.service](https://github.com/OLIMEX/DIY-LAPTOP/blob/master/SOFTWARE/A64-TERES/teres1-ledctrl/debian/teres1-ledctrl.service) looks OK.