### PR TITLE
Supplementary Ubuntu 18.04.2 images with GUI (kde or dwm) and a switch to ppa:ayufan/pine64-ppa

### DIFF
--- a/SOFTWARE/A64-TERES/scripts/make_rootfs.sh
+++ b/SOFTWARE/A64-TERES/scripts/make_rootfs.sh
@@ -298,7 +298,7 @@ EOF
 			DEBUSERPW=olimex
 			ADDPPACMD="apt-get -y update && \
 				apt-get install -y software-properties-common && \
-				apt-add-repository -y ppa:longsleep/ubuntu-pine64-flavour-makers \
+				apt-add-repository -y ppa:ayufan/pine64-ppa \
 			"
 			EXTRADEBS="\
 				zram-config \

--- a/SOFTWARE/A64-TERES/scripts/make_rootfs.sh
+++ b/SOFTWARE/A64-TERES/scripts/make_rootfs.sh
@@ -77,7 +77,7 @@ case $DISTRO in
 	xenial)
 		ROOTFS="http://cdimage.ubuntu.com/ubuntu-base/releases/16.04.2/release/ubuntu-base-16.04.2-base-arm64.tar.gz"
 		;;
-	bionic)
+	bionic|kde)
 		ROOTFS="http://cdimage.ubuntu.com/ubuntu-base/releases/18.04.2/release/ubuntu-base-18.04-base-arm64.tar.gz"
 		;;
 	sid|jessie)
@@ -238,6 +238,10 @@ EOF
 
 add_ubuntu_apt_sources() {
 	local release="$1"
+	# Use Ubuntu 18.04 bionic repositories for KDE image
+	if [ "$release" = "kde" ]; then
+		release="bionic"
+	fi
 	cat > "$DEST/etc/apt/sources.list" <<EOF
 deb http://ports.ubuntu.com/ ${release} main restricted universe multiverse
 deb-src http://ports.ubuntu.com/ ${release} main restricted universe multiverse
@@ -285,10 +289,10 @@ EOF
 		rm -f "$DEST/etc/resolv.conf"
 		mv "$DEST/etc/resolv.conf.dist" "$DEST/etc/resolv.conf"
 		;;
-	xenial|bionic|sid|jessie)
+	xenial|bionic|sid|jessie|kde)
 		rm "$DEST/etc/resolv.conf"
 		cp /etc/resolv.conf "$DEST/etc/resolv.conf"
-		if [ "$DISTRO" = "xenial" -o "$DISTRO" = "bionic" ]; then
+		if [ "$DISTRO" = "xenial" -o "$DISTRO" = "bionic" -o "$DISTRO" = "kde" ]; then
 			DEB=ubuntu
 			DEBUSER=olimex
 			DEBUSERPW=olimex
@@ -307,6 +311,10 @@ EOF
 				rsync \
 				blueman \
 			"
+			if [ "$DISTRO" = "kde" ]; then
+				# Additional KDE packages
+				EXTRADEBS+=" kde-plasma-desktop "
+			fi
 		elif [ "$DISTRO" = "sid" -o "$DISTRO" = "jessie" ]; then
 			DEB=debian
 			DEBUSER=olimex

--- a/SOFTWARE/A64-TERES/scripts/make_rootfs.sh
+++ b/SOFTWARE/A64-TERES/scripts/make_rootfs.sh
@@ -77,7 +77,7 @@ case $DISTRO in
 	xenial)
 		ROOTFS="http://cdimage.ubuntu.com/ubuntu-base/releases/16.04.2/release/ubuntu-base-16.04.2-base-arm64.tar.gz"
 		;;
-	bionic|kde)
+	bionic|kde|geek)
 		ROOTFS="http://cdimage.ubuntu.com/ubuntu-base/releases/18.04.2/release/ubuntu-base-18.04-base-arm64.tar.gz"
 		;;
 	sid|jessie)
@@ -239,7 +239,7 @@ EOF
 add_ubuntu_apt_sources() {
 	local release="$1"
 	# Use Ubuntu 18.04 bionic repositories for KDE image
-	if [ "$release" = "kde" ]; then
+	if [ "$release" = "kde" -o "$release" = "geek" ]; then
 		release="bionic"
 	fi
 	cat > "$DEST/etc/apt/sources.list" <<EOF
@@ -289,10 +289,10 @@ EOF
 		rm -f "$DEST/etc/resolv.conf"
 		mv "$DEST/etc/resolv.conf.dist" "$DEST/etc/resolv.conf"
 		;;
-	xenial|bionic|sid|jessie|kde)
+	xenial|bionic|sid|jessie|kde|geek)
 		rm "$DEST/etc/resolv.conf"
 		cp /etc/resolv.conf "$DEST/etc/resolv.conf"
-		if [ "$DISTRO" = "xenial" -o "$DISTRO" = "bionic" -o "$DISTRO" = "kde" ]; then
+		if [ "$DISTRO" = "xenial" -o "$DISTRO" = "bionic" -o "$DISTRO" = "kde" -o "$DISTRO" = "geek" ]; then
 			DEB=ubuntu
 			DEBUSER=olimex
 			DEBUSERPW=olimex
@@ -314,6 +314,16 @@ EOF
 			if [ "$DISTRO" = "kde" ]; then
 				# Additional KDE packages
 				EXTRADEBS+=" kde-plasma-desktop "
+			elif [ "$DISTRO" = "geek" ]; then
+				# Packages for a geek look & feel :)
+				EXTRADEBS+="\
+						xorg \
+						xdm \
+						dwm \
+						surf \
+						stterm \
+						vim \
+				"
 			fi
 		elif [ "$DISTRO" = "sid" -o "$DISTRO" = "jessie" ]; then
 			DEB=debian


### PR DESCRIPTION
Add more options for building images with graphical user interfaces on top of Ubuntu 18.04.2 Bionic:
* **kde** - image with kde plasma desktop
* **geek** - image with a truly geek look and feel provided by dwm, surf web browser and stterm (inspired by a conversation with friends during the last weekend)

Replace ppa:longsleep/ubuntu-pine64-flavour-makers with ppa:ayufan/pine64-ppa because it provides better support of the same deb packages for both Ubuntu 16.04 xenial and Ubuntu 18.04 bionic.

Best regards,
Leon