### PR TITLE
docs: fix heading overlap with floated image in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![OLIMEX Company Logo](doc/images/smflogo.png "OLIMEX Company Logo")
 <img align="right" src="doc/images/TERES-I/TERES-A64-BLACK/laptop-12.jpg">
 
-<br>
+<br clear="right">
 
 # TERES-I
 


### PR DESCRIPTION
Instead of this:
<img width="898" height="396" alt="image" src="https://github.com/user-attachments/assets/bd3699e5-8617-45bb-ada2-3f6bcaf53cf7" />

<hr>

my edit:
<img width="884" height="479" alt="image" src="https://github.com/user-attachments/assets/30d130b3-1b72-4dc6-8dab-1067aa6ce815" />
<br>

### Thanks for this awesome project!


